### PR TITLE
FEAT: JWT 토큰 인증 추가 (#72)

### DIFF
--- a/springboot-app/build.gradle
+++ b/springboot-app/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     implementation group: 'org.javassist', name: 'javassist', version: '3.15.0-GA'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/springboot-app/src/main/java/com/uplus/eureka/candidate/model/service/CandidateService.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/candidate/model/service/CandidateService.java
@@ -2,10 +2,12 @@ package com.uplus.eureka.candidate.model.service;
 
 import com.uplus.eureka.candidate.model.dao.CandidateDao;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
+@Transactional
 public class CandidateService {
 
     private final CandidateDao candidateDao;

--- a/springboot-app/src/main/java/com/uplus/eureka/comment/model/service/CommentServiceImp.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/comment/model/service/CommentServiceImp.java
@@ -11,11 +11,13 @@ import com.uplus.eureka.user.model.dto.User;
 import org.aspectj.apache.bcel.classfile.Code;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.SQLException;
 import java.util.List;
 
 @Service
+@Transactional
 public class CommentServiceImp implements CommentService {
 
     private final CommentDao dao;

--- a/springboot-app/src/main/java/com/uplus/eureka/config/SwaggerConfiguration.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/config/SwaggerConfiguration.java
@@ -1,5 +1,11 @@
 package com.uplus.eureka.config;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.SecuritySchemes;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -9,6 +15,12 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@SecurityScheme(
+		name = "bearerAuth",
+		type = SecuritySchemeType.HTTP,
+		scheme = "bearer",
+		bearerFormat = "JWT"
+)
 @Configuration
 public class SwaggerConfiguration {
 	private Logger logger = LoggerFactory.getLogger(getClass());
@@ -24,7 +36,14 @@ public class SwaggerConfiguration {
 						"<h3>Oh-no-its-me API Reference for Developers</h3>Swagger를 이용한 너로 정했다! 프로젝트 API 문서입니다.<br><img src=\"/eureka/assets/img/logo.png\" width=\"100\">")
 				.version("v1");
 
-		return new OpenAPI().components(new Components()).info(info);
+		return new OpenAPI()
+				.info(info)
+				.addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearerAuth"))
+				.components(new Components().addSecuritySchemes("bearerAuth",
+						new io.swagger.v3.oas.models.security.SecurityScheme()
+								.type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+								.scheme("bearer")
+								.bearerFormat("JWT")));
 	}
 
 	@Bean
@@ -32,6 +51,11 @@ public class SwaggerConfiguration {
 		return GroupedOpenApi.builder()
 				.group("all")
 				.pathsToMatch("/api/**")
+				.addOperationCustomizer((operation, handlerMethod) -> {
+					// Swagger UI에서 JWT 인증을 필수로 하려면, 각 API에 대해 인증을 요구할 수 있도록 설정
+					operation.addSecurityItem(new io.swagger.v3.oas.models.security.SecurityRequirement().addList("bearerAuth"));
+					return operation;
+				})
 				.build();
 	}
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/config/WebMvcConfiguration.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/config/WebMvcConfiguration.java
@@ -32,7 +32,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")         //모든 요청에 대해
-				.allowedOrigins("http://localhost:3000", "http://localhost:3001")
+				.allowedOrigins("http://localhost:3000", "http://localhost:3001", "https://oh-no-its-me.vercel.app")
 //              허용해줄 method 설정   pre-flight에서 options로 요청하지만 head로 오는 경우도 있어서 모두 허용한다.
 				.allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(),
 						HttpMethod.DELETE.name(), HttpMethod.HEAD.name(), HttpMethod.OPTIONS.name(),

--- a/springboot-app/src/main/java/com/uplus/eureka/config/WebMvcConfiguration.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/config/WebMvcConfiguration.java
@@ -5,37 +5,62 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import com.uplus.eureka.interceptor.JWTInterceptor;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Configuration
 @EnableAspectJAutoProxy
 @MapperScan(basePackages = { "com.uplus.**.dao" })
 public class WebMvcConfiguration implements WebMvcConfigurer {
+	private JWTInterceptor jwtInterceptor;
 
+	public WebMvcConfiguration(JWTInterceptor jwtInterceptor) {
+		super();
+		this.jwtInterceptor = jwtInterceptor;
+	}
+
+	/*
+	 * CORS
+	 * 브라우저에서 보낸 pre-flight에 허용할 정보들을 설정한다.
+	 */
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
-		registry.addMapping("/**")
-				.allowedOrigins("*") // 모든 출처 허용 (환경에 따라 조정할 것)
-				.allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(),
-						HttpMethod.PUT.name(), HttpMethod.DELETE.name(),
-						HttpMethod.HEAD.name(), HttpMethod.OPTIONS.name(),
+		registry.addMapping("/**")         //모든 요청에 대해
+				.allowedOrigins("http://localhost:3000", "http://localhost:3001")
+//              허용해줄 method 설정   pre-flight에서 options로 요청하지만 head로 오는 경우도 있어서 모두 허용한다.
+				.allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(),
+						HttpMethod.DELETE.name(), HttpMethod.HEAD.name(), HttpMethod.OPTIONS.name(),
 						HttpMethod.PATCH.name())
-				.maxAge(1800); // Preflight 결과를 1800초 동안 캐시
+//              CORS에 의해 Authorization, Refresh-Token 헤더에 접근 불가하므로 아래 헤더에
+				.allowedHeaders("Authorization", "Refresh-Token", "Content-Type")
+//              응답 헤더 브라우저에서 읽기 허용   ==> 허용하지 않으면 프론트에서 header를 읽으면 null이된다.
+				.exposedHeaders("Authorization", "Refresh-Token")
+				.allowCredentials(true)    // 인증 정보 포함 (쿠키 전송 허용)
+				.maxAge(1800);              // 30분(1800초) 동안 preflight 결과를 캐시에 저장 => 보안 고려
+		// 1시간(3600초) 일반적으로 설정 시간
 	}
 
 	@Override
-	public void addViewControllers(ViewControllerRegistry registry) {
-		registry.addViewController("/").setViewName("index2");
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(jwtInterceptor)
+				.addPathPatterns("/api/**") // 모든 API 경로에 인터셉터 적용
+				.excludePathPatterns("/api/user/login"); // 로그인 경로는 제외
 	}
 
-	// 필요한 경우 주석 해제하여 자원 핸들러 추가
-	// @Override
-	// public void addResourceHandlers(ResourceHandlerRegistry registry) {
-	//     registry.addResourceHandler("/upload/file/**")
-	//             .addResourceLocations("file:///" + uploadFilePath + "/")
-	//             .setCachePeriod(3600)
-	//             .resourceChain(true)
-	//             .addResolver(new PathResourceResolver());
-	// }
+	/**
+	 * resource 요청이 들어왔을때 spring container를 거치지 않고 바로 해당 경로에서 서비스 되도록 설정
+	 */
+	@Override
+	public void addResourceHandlers(ResourceHandlerRegistry registry) {
+		registry.addResourceHandler("/img/**").addResourceLocations("classpath:/static/assets/img/");
+		registry.addResourceHandler("/*.html**").addResourceLocations("classpath:/static/");
+		registry.addResourceHandler("/swagger-ui.html**").addResourceLocations("classpath:/META-INF/resources/swagger-ui.html");
+		registry.addResourceHandler("/webjars/**").addResourceLocations("classpath:/META-INF/resources/webjars/");
+	}
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/interceptor/JWTInterceptor.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/interceptor/JWTInterceptor.java
@@ -1,0 +1,112 @@
+package com.uplus.eureka.interceptor;
+
+import com.uplus.eureka.util.JwtUtil;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.uplus.eureka.user.model.dto.UnAuthorizedException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JWTInterceptor implements HandlerInterceptor {
+
+	private final String HEADER_AUTH = "Authorization";
+	private final String REFRESH_AUTH = "Refresh-Token";
+
+	private JwtUtil jwtUtil;
+
+	public JWTInterceptor(JwtUtil jwtUtil) {
+		super();
+		this.jwtUtil = jwtUtil;
+	}
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+			throws Exception {
+
+		// OPTIONS 요청은 허용 (CORS preflight 요청)
+		if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+			return true;
+		}
+
+		String url = request.getServletPath();
+		String method = request.getMethod();
+		log.debug("JWTInterceptor");
+		log.debug("request url:{} method:{}", url, method);
+
+		// Swagger 및 API 문서 관련 경로는 인증 제외
+		if (url.contains("/swagger") ||
+				url.contains("/v3/api-docs") ||
+				url.contains("/eureka/assets/")) {
+			return true;
+		}
+
+		// 로그인 및 회원가입 요청은 허용
+		if ((url.equals("/api/user/login") && method.equalsIgnoreCase("POST")) ||
+				(url.equals("/api/user") && method.equalsIgnoreCase("POST"))) {
+			return true;
+		}
+
+		// 헤더에서 토큰 추출
+		String accessToken = request.getHeader(HEADER_AUTH);
+		String refreshToken = request.getHeader(REFRESH_AUTH);
+
+		log.debug("accessToken:{}", accessToken);
+		log.debug("refreshToken:{}", refreshToken);
+
+		// Access Token 검증
+		if (accessToken != null) {
+			accessToken = accessToken.replace("Bearer ", "");
+			log.debug("HEADER_AUTH:{}", accessToken);
+			if (jwtUtil.checkToken(accessToken)) {
+				// 유효한 토큰이면 사용자 정보 추출하여 request 속성에 추가
+				Integer userId = jwtUtil.extractUserId(accessToken);
+				String username = jwtUtil.extractUsername(accessToken);
+
+				request.setAttribute("userId", userId);
+				request.setAttribute("username", username);
+
+				log.info("Access Token 사용 가능 : {}", accessToken);
+				return true;
+			}
+		}
+
+		log.info("Access Token 사용 불가능, Refresh Token 검사 시작");
+
+		// Refresh Token 검증 및 Access Token 재발급
+		if (refreshToken != null) {
+			String newAccessToken = jwtUtil.generateAccessTokenFromRefreshToken(refreshToken);
+			if (newAccessToken != null) {
+				log.info("Refresh Token 사용 가능, Access Token 갱신");
+				log.info("재 발행한 access Token:{}", newAccessToken);
+
+				// 새 액세스 토큰으로부터 사용자 정보 추출
+				Integer userId = jwtUtil.extractUserId(newAccessToken);
+				String username = jwtUtil.extractUsername(newAccessToken);
+
+				// 요청에 사용자 정보 추가
+				request.setAttribute("userId", userId);
+				request.setAttribute("username", username);
+
+				// 응답 헤더에 새 액세스 토큰 추가
+				if (!newAccessToken.startsWith("Bearer ")) {
+					newAccessToken = "Bearer " + newAccessToken;
+				}
+				response.addHeader(HEADER_AUTH, newAccessToken);
+
+
+				// 토큰이 갱신되었음을 클라이언트에게 알림
+				response.addHeader("Token-Renewed", "true");
+
+				return true;
+			}
+		}
+
+		log.info("Access Token과 Refresh Token 모두 사용 불가능");
+		throw new UnAuthorizedException();
+	}
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/poll/model/service/PollServiceImp.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/poll/model/service/PollServiceImp.java
@@ -5,8 +5,10 @@ import com.uplus.eureka.poll.model.dto.Question;
 import com.uplus.eureka.poll.model.dao.PollDao;
 import java.util.List;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class PollServiceImp implements PollService {
 
     private final PollDao pollDao;

--- a/springboot-app/src/main/java/com/uplus/eureka/user/controller/TokenController.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/controller/TokenController.java
@@ -1,0 +1,120 @@
+package com.uplus.eureka.user.controller;
+
+import com.uplus.eureka.user.model.dto.TokenResponse;
+import com.uplus.eureka.user.model.dto.User;
+import com.uplus.eureka.user.model.service.UserService;
+import com.uplus.eureka.util.JwtUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Tag(name = "Token Management API", description = "토큰 관리 API")
+@RestController
+@RequestMapping("api/token")
+@Slf4j
+public class TokenController {
+
+	private final JwtUtil jwtUtil;
+	private final UserService userService;
+
+	@Autowired
+	public TokenController(JwtUtil jwtUtil, UserService userService) {
+		this.jwtUtil = jwtUtil;
+		this.userService = userService;
+	}
+
+	@Operation(
+			summary = "토큰 검증",
+			description = "현재 AccessToken의 유효성을 검증합니다.",
+			security = @SecurityRequirement(name = "Bearer Authentication")
+	)
+	@ApiResponse(responseCode = "200", description = "유효한 토큰")
+	@ApiResponse(responseCode = "401", description = "유효하지 않은 토큰")
+	@GetMapping("/validate")
+	public ResponseEntity<?> validateToken(
+			@RequestHeader("Authorization") String authHeader,
+			@RequestAttribute(name = "userId", required = false) Integer userId,
+			@RequestAttribute(name = "username", required = false) String username) {
+
+		try {
+			if (userId == null || username == null) {
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+			}
+
+			Map<String, Object> response = new HashMap<>();
+			response.put("valid", true);
+			response.put("userId", userId);
+			response.put("username", username);
+
+			return ResponseEntity.ok(response);
+		} catch (Exception e) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 토큰입니다.");
+		}
+	}
+
+	@Operation(
+			summary = "토큰 갱신",
+			description = "Refresh Token을 사용해 Access Token을 갱신합니다."
+	)
+	@ApiResponse(responseCode = "200", description = "토큰 갱신 성공")
+	@ApiResponse(responseCode = "401", description = "유효하지 않은 Refresh Token")
+	@PostMapping("/refresh")
+	public ResponseEntity<?> refreshToken(
+			@Parameter(description = "Refresh Token", required = true, in = ParameterIn.HEADER)
+			@RequestHeader("Refresh-Token") String refreshToken) {
+
+		try {
+			String newAccessToken = jwtUtil.generateAccessTokenFromRefreshToken(refreshToken);
+
+			if (newAccessToken == null) {
+				return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 Refresh Token입니다.");
+			}
+
+			TokenResponse tokenResponse = new TokenResponse();
+			tokenResponse.setAccessToken("Bearer " + newAccessToken);
+
+			return ResponseEntity
+					.ok()
+					.header("Authorization", "Bearer " + newAccessToken)
+					.body(tokenResponse);
+		} catch (Exception e) {
+			log.error("토큰 갱신 실패: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 Refresh Token입니다.");
+		}
+	}
+
+	@Operation(
+			summary = "로그아웃",
+			description = "사용자의 Refresh Token을 무효화합니다.",
+			security = @SecurityRequirement(name = "Bearer Authentication")
+	)
+	@ApiResponse(responseCode = "200", description = "로그아웃 성공")
+	@ApiResponse(responseCode = "401", description = "인증 실패")
+	@PostMapping("/logout")
+	public ResponseEntity<?> logout(
+			@RequestAttribute(name = "userId", required = false) Integer userId) {
+
+		if (userId == null) {
+			return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+		}
+
+		try {
+			userService.deleteRefreshToken(userId);
+			return ResponseEntity.ok("로그아웃 성공");
+		} catch (Exception e) {
+			log.error("로그아웃 실패: {}", e.getMessage());
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("로그아웃 실패");
+		}
+	}
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/user/controller/UserController.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/controller/UserController.java
@@ -2,9 +2,11 @@ package com.uplus.eureka.user.controller;
 
 import com.uplus.eureka.user.model.dto.LoginRequest;
 import com.uplus.eureka.user.model.dto.PasswordUpdateRequest;
+import com.uplus.eureka.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.*;
 import com.uplus.eureka.user.model.dto.User;
 import com.uplus.eureka.user.model.service.UserService;
 import com.uplus.eureka.user.model.dto.UserException;
+
+import java.util.HashMap;
 import java.util.Map;
 
 @Tag(name = "User Management API", description = "유저 관리 API")
@@ -21,13 +25,15 @@ import java.util.Map;
 public class UserController {
 
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @Autowired
-    public UserController(UserService userService) {
+    public UserController(UserService userService, JwtUtil jwtUtil) {
         this.userService = userService;
+        this.jwtUtil = jwtUtil;
     }
 
-    @Operation(summary = "로그인", description = "이름과 비밀번호를 사용해서 로그인")
+    @Operation(summary = "로그인", description = "이름과 비밀번호를 사용해서 로그인하고 JWT 토큰 발급")
     @ApiResponse(responseCode = "200", description = "로그인 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 요청, 유저 ID 또는 비밀번호가 잘못됨")
     @PostMapping("/login")
@@ -44,39 +50,99 @@ public class UserController {
             // 사용자 로그인 시도
             User loggedInUser = userService.login(loginRequest.getUsername(), loginRequest.getPassword());
 
-            // loggedInUser.setPassword(null);
+            // 비밀번호 정보는 응답에서 제거
+            User userWithoutPassword = new User();
+            userWithoutPassword.setUserId(loggedInUser.getUserId());
+            userWithoutPassword.setUsername(loggedInUser.getUsername());
+            userWithoutPassword.setImg(loggedInUser.getImg());
+            userWithoutPassword.setSelected(loggedInUser.isSelected());
+            userWithoutPassword.setRandomNickname(loggedInUser.getRandomNickname());
+            userWithoutPassword.setVoted(loggedInUser.isVoted());
 
-            return ResponseEntity.ok(loggedInUser); // User 객체 반환
+            // JWT 토큰 생성
+            String accessToken = jwtUtil.generateAccessToken(loggedInUser);
+            String refreshToken = jwtUtil.generateRefreshToken(loggedInUser);
+
+            // DB에 리프레시 토큰 저장
+            userService.saveRefreshToken(loggedInUser.getUserId(), refreshToken);
+
+            // 응답 생성
+            Map<String, Object> response = new HashMap<>();
+            response.put("user", userWithoutPassword);
+            response.put("message", "로그인 성공");
+
+            // 토큰을 헤더에 추가
+            HttpStatus status = HttpStatus.OK;
+            return ResponseEntity.status(status)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .header("Refresh-Token", refreshToken)
+                    .body(response);
         } catch (UserException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
         }
     }
 
-    @Operation(summary = "유저 정보 조회", description = "유저 아이디로 유저 정보를 조회")
+    @Operation(
+            summary = "유저 정보 조회",
+            description = "유저 아이디로 유저 정보를 조회 (인증 필요)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
     @ApiResponse(responseCode = "200", description = "유저 정보 조회 성공")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
+    @ApiResponse(responseCode = "403", description = "권한 없음")
     @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
     @GetMapping("/{userId}")
     public ResponseEntity<?> getUser(
-            @Parameter(description = "User ID", required = true) @PathVariable("userId") Integer userId) {
+            @Parameter(description = "User ID", required = true) @PathVariable("userId") Integer userId,
+            @RequestAttribute(name = "userId", required = false) Integer tokenUserId) {
+
+        // 토큰 검증: 토큰이 유효하고 사용자가 인증되었는지 확인
+        if (tokenUserId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+        }
+
+        // 권한 검증: 본인 정보만 조회 가능하도록 설정 (필요에 따라 관리자 권한 추가 가능)
+        if (!tokenUserId.equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("다른 사용자의 정보를 조회할 권한이 없습니다.");
+        }
+
         try {
             User user = userService.getUser(userId);
+            // 비밀번호 정보는 응답에서 제거
+            user.setPassword(null);
             return ResponseEntity.ok(user);
         } catch (UserException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
         }
     }
 
-    @Operation(summary = "비밀번호 변경", description = "특정 유저의 비밀번호 변경")
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "특정 유저의 비밀번호 변경 (인증 필요)",
+            security = @SecurityRequirement(name = "Bearer Authentication")
+    )
     @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    @ApiResponse(responseCode = "401", description = "인증 실패")
     @ApiResponse(responseCode = "403", description = "권한 없음")
     @PatchMapping("/{userId}")
     public ResponseEntity<?> updatePassword(
             @PathVariable("userId") Integer userId,
-            @RequestBody PasswordUpdateRequest passwordUpdateRequest) {
+            @RequestBody PasswordUpdateRequest passwordUpdateRequest,
+            @RequestAttribute(name = "userId", required = false) Integer tokenUserId) {
 
-        String oldPassword = passwordUpdateRequest.getOld_password(); // 수정된 코드
-        String newPassword = passwordUpdateRequest.getNew_password(); // 수정된 코드
+        // 토큰 검증: 토큰이 유효하고 사용자가 인증되었는지 확인
+        if (tokenUserId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증이 필요합니다.");
+        }
+
+        // 토큰 기반 사용자 검증 (본인 확인)
+        if (!tokenUserId.equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("비밀번호 변경 권한이 없습니다.");
+        }
+
+        String oldPassword = passwordUpdateRequest.getOld_password();
+        String newPassword = passwordUpdateRequest.getNew_password();
 
         // 사용자 정보 조회
         User user = userService.getUser(userId);
@@ -84,10 +150,10 @@ public class UserController {
 
         // 비밀번호 유효성 검사
         if (!oldPassword.equals(currentPassword)) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("비밀번호 변경 실패");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("현재 비밀번호가 일치하지 않습니다.");
         } else {
             if (oldPassword.equals(newPassword)) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("비밀번호가 동일합니다.");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("새 비밀번호가 현재 비밀번호와 동일합니다.");
             } else {
                 userService.updatePassword(userId, newPassword);
                 return ResponseEntity.ok("비밀번호 변경 성공");

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dao/UserDao.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dao/UserDao.java
@@ -1,3 +1,5 @@
+
+
 package com.uplus.eureka.user.model.dao;
 
 import java.util.Map;
@@ -12,4 +14,7 @@ public interface UserDao {
 	User getUser(Integer userId);
 	void updatePassword(Map<String, Object> paramMap);
 	User getUserByUsername(String username);
+	void saveRefreshToken(Map<String, Object> map);
+	String getRefreshToken(String userId);
+	void deleteRefreshToken(Map<String, Object> map);
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/LoginResponse.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.uplus.eureka.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+	private User user;
+	private String token;
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/TokenResponse.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.uplus.eureka.user.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+	@Schema(description = "Access Token", example = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+	private String accessToken;
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/UnAuthorizedException.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/UnAuthorizedException.java
@@ -1,0 +1,13 @@
+package com.uplus.eureka.user.model.dto;
+
+public class UnAuthorizedException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+
+	public UnAuthorizedException() {
+		super("권한이 없습니다.");
+	}
+
+	public UnAuthorizedException(String message) {
+		super(message);
+	}
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/User.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/User.java
@@ -31,4 +31,7 @@ public class User implements Serializable {
 
 	@Schema(description = "투표여부", example = "false")
 	private boolean isVoted;
+
+	@Schema(description = "JWT 토큰", example = "eyJhbGciOiJIUzI1Ni...")
+	private String token; //
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/service/UserService.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/service/UserService.java
@@ -6,5 +6,7 @@ public interface UserService {
 	User login(String username, String pass);
 	User getUser(Integer userId);
 	void updatePassword(Integer userId, String new_pass);
+	void saveRefreshToken(Integer userId, String refreshToken);
+	String getRefreshToken(Integer userId);
+	void deleteRefreshToken(Integer userId);
 }
-

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/service/UserServiceImp.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/service/UserServiceImp.java
@@ -8,8 +8,10 @@ import org.springframework.stereotype.Service;
 import com.uplus.eureka.user.model.dao.UserDao;
 import com.uplus.eureka.user.model.dto.User;
 import com.uplus.eureka.user.model.dto.UserException;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class UserServiceImp implements UserService {
 
 	private final UserDao dao;
@@ -51,7 +53,7 @@ public class UserServiceImp implements UserService {
 			throw new UserException("등록되지 않은 아이디입니다.");
 		}
 
-		// 비밀번호 비교 로직	
+		// 비밀번호 비교 로직
 		if (newPassword.equals(user.getPassword())) {
 			throw new UserException("현재 비밀번호와 동일합니다.");
 		}
@@ -60,5 +62,26 @@ public class UserServiceImp implements UserService {
 		paramMap.put("userId", userId);
 		paramMap.put("newPassword", newPassword);
 		dao.updatePassword(paramMap);
+	}
+
+	@Override
+	public void saveRefreshToken(Integer userId, String refreshToken) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("userId", userId);
+		map.put("token", refreshToken);
+		dao.saveRefreshToken(map);
+	}
+
+	@Override
+	public String getRefreshToken(Integer userId) {
+		return dao.getRefreshToken(userId.toString());
+	}
+
+	@Override
+	public void deleteRefreshToken(Integer userId) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("userId", userId);
+		map.put("token", null);
+		dao.deleteRefreshToken(map);
 	}
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/util/JwtUtil.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/util/JwtUtil.java
@@ -1,0 +1,123 @@
+package com.uplus.eureka.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import com.uplus.eureka.user.model.dto.User;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class JwtUtil {
+
+	@Value("${jwt.secret:defaultSecretKeyWhichShouldBeVeryLongForSecurityReasons}")
+	private String SECRET_KEY;
+
+	@Value("3600000")
+	private long accessTokenExpiration;
+
+	@Value("${jwt.refresh.expiration:604800000}")
+	private long refreshTokenExpiration;
+
+	private Key getSigningKey() {
+		byte[] keyBytes = SECRET_KEY.getBytes();
+		return Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public String extractUsername(String token) {
+		return extractClaim(token, Claims::getSubject);
+	}
+
+	public Integer extractUserId(String token) {
+		final Claims claims = extractAllClaims(token);
+		return claims.get("userId", Integer.class);
+	}
+
+	public Date extractExpiration(String token) {
+		return extractClaim(token, Claims::getExpiration);
+	}
+
+	public <T> T extractClaim(String token, Function<Claims, T> claimsResolver) {
+		final Claims claims = extractAllClaims(token);
+		return claimsResolver.apply(claims);
+	}
+
+	public Claims extractAllClaims(String token) {
+		return Jwts.parser()
+				.setSigningKey(getSigningKey())
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+	}
+
+	private Boolean isTokenExpired(String token) {
+		return extractExpiration(token).before(new Date());
+	}
+
+	// 토큰 유효성 검사
+	public boolean checkToken(String token) {
+		try {
+			return !isTokenExpired(token);
+		} catch (Exception e) {
+			log.error("토큰 검증 실패: {}", e.getMessage());
+			return false;
+		}
+	}
+
+	public String generateAccessToken(User user) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("userId", user.getUserId());
+		return createToken(claims, user.getUsername(), accessTokenExpiration);
+	}
+
+	public String generateRefreshToken(User user) {
+		Map<String, Object> claims = new HashMap<>();
+		claims.put("userId", user.getUserId());
+		claims.put("type", "refresh");
+		return createToken(claims, user.getUsername(), refreshTokenExpiration);
+	}
+
+	private String createToken(Map<String, Object> claims, String subject, long expiration) {
+		return Jwts.builder()
+				.setClaims(claims)
+				.setSubject(subject)
+				.setIssuedAt(new Date(System.currentTimeMillis()))
+				.setExpiration(new Date(System.currentTimeMillis() + expiration))
+				.signWith(getSigningKey(), SignatureAlgorithm.HS256)
+				.compact();
+	}
+
+	public String generateAccessTokenFromRefreshToken(String refreshToken) {
+		try {
+			if (!checkToken(refreshToken)) {
+				log.error("Refresh 토큰이 만료되었습니다.");
+				return null;
+			}
+
+			Claims claims = extractAllClaims(refreshToken);
+			if (!"refresh".equals(claims.get("type"))) {
+				log.error("유효한 Refresh 토큰이 아닙니다.");
+				return null;
+			}
+
+			Integer userId = claims.get("userId", Integer.class);
+			String username = claims.getSubject();
+
+			Map<String, Object> newClaims = new HashMap<>();
+			newClaims.put("userId", userId);
+
+			return createToken(newClaims, username, accessTokenExpiration);
+		} catch (Exception e) {
+			log.error("액세스 토큰 재발급 실패: {}", e.getMessage());
+			return null;
+		}
+	}
+}

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteServiceImp.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteServiceImp.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 
 @Service
+@Transactional
 public class VoteServiceImp implements VoteService {
 
     private final VoteDao voteDao;
@@ -40,7 +41,6 @@ public class VoteServiceImp implements VoteService {
     }
 
     @Override
-    @Transactional
     public void increaseVoteCount(int pollId, VoteRequest voteRequest) {
         int updatedRows = voteDao.incrementVoteCount(voteRequest);
         if (updatedRows == 0) {

--- a/springboot-app/src/main/resources/application.properties
+++ b/springboot-app/src/main/resources/application.properties
@@ -8,8 +8,8 @@ spring.datasource.hikari.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.hikari.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.datasource.hikari.pool-name=hikari-pool
-spring.datasource.hikari.maximum-pool-size=50
-spring.datasource.hikari.minimum-idle=50
+spring.datasource.hikari.maximum-pool-size=1
+spring.datasource.hikari.minimum-idle=1
 spring.datasource.hikari.connection-timeout=5000
 spring.datasource.hikari.connection-init-sql=SELECT 1
 spring.datasource.hikari.idle-timeout=600000
@@ -26,8 +26,21 @@ mybatis.type-aliases-package=com.uplus.eureka.*.model.dto
 mybatis.mapper-locations=classpath:mapper/*.xml
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
 
+# JWT setting
+jwt.secret=${JWT_SECRET}
+jwt.expiration=86400000
+jwt.refresh.expiration=604800000
+
 # swagger Setting
 springdoc.api-docs.enabled=true
+springdoc.paths-to-match=/**
 springdoc.swagger-ui.enabled=true
 springdoc.swagger-ui.path=/swagger-ui/index.html
 springdoc.override-with-generic-response=false
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.operations-sorter=alpha
+springdoc.api-docs.path=/v3/api-docs
+springdoc.api-docs.groups.enabled=true
+springdoc.cache.disabled=true
+springdoc.default-consumes-media-type=application/json;charset=UTF-8
+springdoc.default-produces-media-type=application/json;charset=UTF-8

--- a/springboot-app/src/main/resources/mapper/comments.xml
+++ b/springboot-app/src/main/resources/mapper/comments.xml
@@ -20,34 +20,34 @@
     <!-- 특정 comment_id에 대한 댓글 조회 -->
     <select id="getCommentById" resultMap="commentResultMap" parameterType="Integer">
         SELECT c.comment_id, c.user_id, u.random_nickname, c.comment_text
-        FROM comments c
-                 JOIN users u ON c.user_id = u.user_id
+        FROM Comments c
+                 JOIN Users u ON c.user_id = u.user_id
         WHERE c.comment_id = #{commentId}
     </select>
 
     <!-- 모든 댓글 조회 -->
     <select id="getAllComments" resultMap="commentResultMap">
         SELECT c.comment_id, c.user_id, u.random_nickname, c.comment_text
-        FROM comments c
-                 JOIN users u ON c.user_id = u.user_id
+        FROM Comments c
+                 JOIN Users u ON c.user_id = u.user_id
     </select>
 
     <!-- 댓글 수정 -->
     <update id="updateComment" parameterType="com.uplus.eureka.comment.model.dto.CommentUpdateRequest">
-        UPDATE comments
+        UPDATE Comments
         SET comment_text = #{commentText}, user_id = #{userId}
         WHERE comment_id = #{commentId}
     </update>
 
 
     <insert id="insertComment" parameterType="com.uplus.eureka.comment.model.dto.CommentRequest">
-        INSERT INTO comments (user_id, comment_text)
+        INSERT INTO Comments (user_id, comment_text)
         VALUES (#{userId}, #{commentText})
     </insert>
 
     <!-- 특정 comment_id에 대한 댓글 삭제 -->
     <delete id="deleteCommentById" parameterType="com.uplus.eureka.comment.model.dto.CommentDeleteRequest">
-        DELETE FROM comments WHERE comment_id = #{commentId}
+        DELETE FROM Comments WHERE comment_id = #{commentId}
     </delete>
 
 </mapper>

--- a/springboot-app/src/main/resources/mapper/poll.xml
+++ b/springboot-app/src/main/resources/mapper/poll.xml
@@ -11,14 +11,14 @@
     <!-- 랜덤 4개 질문을 가져오는 쿼리 -->
     <select id="getQuestions" resultMap="questionResultMap">
         SELECT question_id, question_text
-        FROM questions
+        FROM Questions
         ORDER BY RAND()
         LIMIT 4
     </select>
     
     <!-- Poll 데이터 삽입 -->
 	<insert id="putQuestions" parameterType="com.uplus.eureka.poll.model.dto.Question">
-	    INSERT INTO polls(question_id, start_time, end_time)
+	    INSERT INTO Polls(question_id, start_time, end_time)
 	    VALUES (#{questionId}, #{startTime}, #{endTime})
 	</insert>
 

--- a/springboot-app/src/main/resources/mapper/users.xml
+++ b/springboot-app/src/main/resources/mapper/users.xml
@@ -3,42 +3,39 @@
 
 <mapper namespace="com.uplus.eureka.user.model.dao.UserDao">
 
-	<!-- 매핑 -->
 	<resultMap id="userResultMap" type="com.uplus.eureka.user.model.dto.User">
-		<result property="userId" column="user_id"/> <!-- user_id -> userId -->
-		<result property="username" column="user_name"/> <!-- user_name -> username -->
+		<result property="userId" column="user_id"/>
+		<result property="username" column="user_name"/>
 		<result property="password" column="password"/>
 		<result property="img" column="img"/>
-		<result property="isSelected" column="is_selected"/> <!-- is_selected -> isSelected -->
+		<result property="isSelected" column="is_selected"/>
 		<result property="randomNickname" column="random_nickname"/>
 		<result property="isVoted" column="is_voted"/>
+		<result property="token" column="token"/>
 	</resultMap>
 
-	<!-- 로그인 -->
-	<select id="login" parameterType="java.util.Map" resultMap="userResultMap">
-		SELECT user_id, user_name, password, img, is_selected, random_nickname, is_voted
-		FROM Users
-		WHERE user_name = #{username} AND password = #{password};
-	</select>
-
-	<!-- 사용자 ID로 사용자 정보 확인 -->
-	<select id="getUser" parameterType="java.lang.Integer" resultMap="userResultMap">
-		SELECT user_id, user_name, password, img, is_selected, random_nickname, is_voted
-		FROM Users
-		WHERE user_id = #{userId};
-	</select>
-
-	<!-- 사용자 이름으로 사용자 조회 -->
 	<select id="getUserByUsername" parameterType="String" resultMap="userResultMap">
-		SELECT user_id, user_name, password, img, is_selected, random_nickname, is_voted
-		FROM Users
-		WHERE user_name = #{username}
+		SELECT * FROM Users WHERE user_name = #{username}
 	</select>
 
-	<!-- 비밀번호 변경 -->
-	<update id="updatePassword" parameterType="java.util.Map">
-		UPDATE Users
-		SET password = #{newPassword}
-		WHERE user_id = #{userId};
+	<select id="getUser" parameterType="Integer" resultMap="userResultMap">
+		SELECT * FROM Users WHERE user_id = #{userId}
+	</select>
+
+	<update id="updatePassword" parameterType="map">
+		UPDATE Users SET password = #{password} WHERE user_id = #{userId}
 	</update>
+
+	<update id="saveRefreshToken" parameterType="map">
+		UPDATE Users SET token = #{token} WHERE user_id = #{userId}
+	</update>
+
+	<select id="getRefreshToken" parameterType="string" resultType="string">
+		SELECT token FROM Users WHERE user_id = #{userId}
+	</select>
+
+	<update id="deleteRefreshToken" parameterType="map">
+		UPDATE Users SET token = #{token, jdbcType=VARCHAR} WHERE user_id = #{userId}
+	</update>
+
 </mapper>

--- a/springboot-app/src/main/resources/mapper/vote.xml
+++ b/springboot-app/src/main/resources/mapper/vote.xml
@@ -30,7 +30,7 @@
 
     <!-- 투표 수 증가 -->
     <update id="incrementVoteCount">
-        UPDATE mini4.Candidates
+        UPDATE Candidates
         SET vote_count = vote_count + 1
         WHERE candidate_id = #{candidate_id}
     </update>


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #72 

## 📝작업 내용
- `JwtUtil` 유틸리티 클래스 추가: JWT 생성, 검증, 정보 추출 기능 구현
- `JWTInterceptor` 추가: 모든 API 요청에서 토큰 인증 수행
- `TokenController` 추가: 토큰 검증, 갱신, 로그아웃 API 구현
- 모든 서비스 계층 클래스에 트랜잭션 어노테이션(`@Transactional`) 추가

### 1. `JwtUtil` - JWT 토큰 관리 유틸리티
- **Access Token**과 **Refresh Token** 발급 
- 토큰에서 사용자 ID, username 추출 
- 토큰의 만료 여부 검사 및 Refresh Token을 통한 Access Token 재발급

### 2. `JWTInterceptor` - 요청 인터셉터
- Access Token이 유효한 경우 사용자 정보 추출 후 요청 속성에 추가
- Access Token 만료 시 Refresh Token을 검증하여 Access Token 자동 재발급 
- 로그인(`POST /api/user/login`)을 제외한 모든 API 요청에 대해 토큰 인증 적용
- Swagger, API 문서 관련 요청은 토큰 인증 제외 처리

### 3. `TokenController` - 토큰 API
> 일단 내부적으로 엑세스 토큰을 갱신되게끔 해놓았으나, 클라이언트에서 요청할 수 있도록 API도 따로 만들었습니다! 
- **GET `/api/token/validate`** : 현재 Access Token 유효성 검증
- **POST `/api/token/refresh`** : Refresh Token을 통한 Access Token 갱신
- **POST `/api/token/logout`** : 서버 저장 Refresh Token 삭제 (로그아웃 처리)

## 📄 참고 사항
### `application.properites`파일이 업데이트되었습니다. 개발용이랑 배포용이 구분되어 있으니, 노션 문서의 배포 페이지에서 확인해주세요☺️
- 토큰은 헤더에 `Authorization: Bearer <토큰>` 형식으로 전달됩니다.
  - 스웨거에 입력할때는 <토큰>만 입력하시면 잘 동작합니다.
- 클라이언트 단에서는 토큰 갱신 시 응답 헤더(`Token-Renewed: true`)를 통해 갱신 여부를 확인할 수 있습니다.

### 스크린샷 (선택)
<img width="1318" alt="스크린샷 2025-04-27 오후 6 15 07" src="https://github.com/user-attachments/assets/8cf7f403-9567-4eb9-aa2e-c414b4cba3a1" />
<img width="1277" alt="스크린샷 2025-04-27 오후 6 14 08" src="https://github.com/user-attachments/assets/7e811b14-bd0d-4212-83a5-67eb8b0a22b0" />







