### PR TITLE
FEAT: #83 Redux 전역 상태관리 초기 설정 및 로그인 API 모듈화

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -8,12 +8,16 @@
       "name": "base-react",
       "version": "0.0.0",
       "dependencies": {
+        "@reduxjs/toolkit": "^2.7.0",
         "@tailwindcss/vite": "^4.1.3",
         "@tanstack/react-query": "^5.74.11",
         "axios": "^1.8.4",
+        "dayjs": "^1.11.13",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-redux": "^9.2.0",
         "react-router-dom": "^7.5.2",
+        "redux-persist": "^6.0.0",
         "tailwindcss": "^4.1.3"
       },
       "devDependencies": {
@@ -21,6 +25,7 @@
         "@types/babel__generator": "^7.27.0",
         "@types/react": "^19.0.12",
         "@types/react-dom": "^19.0.4",
+        "@types/react-redux": "^7.1.34",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -272,6 +277,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -930,6 +944,31 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.7.0.tgz",
+      "integrity": "sha512-XVwolG6eTqwV0N8z/oDlN93ITCIGIop6leXlGJI/4EKy+0POYkR+ABHRSdGXY+0MQvJBP8yAzh+EYFxTuvmBiQ==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.38.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.38.0.tgz",
@@ -1176,6 +1215,16 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.3",
@@ -1460,6 +1509,16 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
     },
+    "node_modules/@types/hoist-non-react-statics": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1481,7 +1540,7 @@
       "version": "19.0.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
       "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1494,6 +1553,32 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/react-redux": {
+      "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.3.0",
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0",
+        "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2195,7 +2280,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2247,6 +2332,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -3566,6 +3656,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3573,6 +3672,15 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4886,6 +4994,28 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -4934,6 +5064,27 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -4975,6 +5126,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -5785,6 +5941,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -10,12 +10,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@reduxjs/toolkit": "^2.7.0",
     "@tailwindcss/vite": "^4.1.3",
     "@tanstack/react-query": "^5.74.11",
     "axios": "^1.8.4",
+    "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-redux": "^9.2.0",
     "react-router-dom": "^7.5.2",
+    "redux-persist": "^6.0.0",
     "tailwindcss": "^4.1.3"
   },
   "devDependencies": {
@@ -23,6 +27,7 @@
     "@types/babel__generator": "^7.27.0",
     "@types/react": "^19.0.12",
     "@types/react-dom": "^19.0.4",
+    "@types/react-redux": "^7.1.34",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -2,7 +2,8 @@ import { Provider } from 'react-redux';
 import { PersistGate } from 'redux-persist/integration/react';
 import { store, persistor } from './store';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import FontTest from '@/components/FontTest';
+import { RouterProvider } from 'react-router-dom';
+import router from './routes';
 
 function App() {
   const queryClient = new QueryClient();
@@ -11,7 +12,7 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
         <PersistGate loading={null} persistor={persistor}>
-          <FontTest />
+          <RouterProvider router={router} />
         </PersistGate>
       </Provider>
     </QueryClientProvider>

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -1,12 +1,19 @@
-import FontTest from '@/components/FontTest';
+import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import { store, persistor } from './store';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import FontTest from '@/components/FontTest';
 
 function App() {
   const queryClient = new QueryClient();
-  
+
   return (
     <QueryClientProvider client={queryClient}>
-      <FontTest />
+      <Provider store={store}>
+        <PersistGate loading={null} persistor={persistor}>
+          <FontTest />
+        </PersistGate>
+      </Provider>
     </QueryClientProvider>
   );
 }

--- a/react-app/src/apis/axiosInstance.ts
+++ b/react-app/src/apis/axiosInstance.ts
@@ -1,8 +1,46 @@
 import axios from 'axios';
+import { store } from '@/store';
+import { setAuth, clearAuth } from '@/store/slices/authSlice';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   withCredentials: true,
+  headers: { 'Content-Type': 'application/json' },
 });
+
+axiosInstance.interceptors.request.use((config) => {
+  const token = store.getState().auth.accessToken;
+  if (token) config.headers['Authorization'] = `Bearer ${token}`;
+  return config;
+});
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = store.getState().auth.refreshToken;
+        const res = await axios.post(
+          '/api/token/refresh',
+          {},
+          {
+            headers: { 'Refresh-Token': refreshToken },
+          },
+        );
+        const { accessToken } = res.data;
+        store.dispatch(setAuth({ ...store.getState().auth, accessToken }));
+        originalRequest.headers['Authorization'] = `Bearer ${accessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        store.dispatch(clearAuth());
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default axiosInstance;

--- a/react-app/src/apis/axiosInstance.ts
+++ b/react-app/src/apis/axiosInstance.ts
@@ -2,18 +2,21 @@ import axios from 'axios';
 import { store } from '@/store';
 import { setAuth, clearAuth } from '@/store/slices/authSlice';
 
+// axios 인스턴스 생성 (baseURL, 헤더 등)
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   withCredentials: true,
   headers: { 'Content-Type': 'application/json' },
 });
 
+// 요청 시 accessToken이 있으면 Authorization 헤더에 자동 추가
 axiosInstance.interceptors.request.use((config) => {
   const token = store.getState().auth.accessToken;
   if (token) config.headers['Authorization'] = `Bearer ${token}`;
   return config;
 });
 
+// 401 응답 발생 시 refresh token으로 accessToken 갱신 시도
 axiosInstance.interceptors.response.use(
   (response) => response,
   async (error) => {

--- a/react-app/src/apis/user/login.ts
+++ b/react-app/src/apis/user/login.ts
@@ -6,17 +6,22 @@ export interface LoginRequest {
 }
 
 export interface LoginResponse {
-  message: string;
   user: {
     userId: number;
-    username: string;
-    randomNickname: string;
-    accessToken: string;
-    refreshToken: string;
+    voted: boolean;
   };
+  accessToken: string | null;
+  refreshToken: string | null;
 }
 
 export async function login(params: LoginRequest): Promise<LoginResponse> {
   const response = await axiosInstance.post('/user/login', params);
-  return response.data;
+  const accessToken = response.headers['authorization']?.replace('Bearer ', '');
+  const refreshToken = response.headers['refresh-token'];
+
+  return {
+    user: response.data.user,
+    accessToken,
+    refreshToken,
+  };
 }

--- a/react-app/src/apis/user/login.ts
+++ b/react-app/src/apis/user/login.ts
@@ -11,6 +11,8 @@ export interface LoginResponse {
     userId: number;
     username: string;
     randomNickname: string;
+    accessToken: string;
+    refreshToken: string;
   };
 }
 

--- a/react-app/src/apis/user/login.ts
+++ b/react-app/src/apis/user/login.ts
@@ -1,0 +1,20 @@
+import axiosInstance from '../axiosInstance';
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  message: string;
+  user: {
+    userId: number;
+    username: string;
+    randomNickname: string;
+  };
+}
+
+export async function login(params: LoginRequest): Promise<LoginResponse> {
+  const response = await axiosInstance.post('/user/login', params);
+  return response.data;
+}

--- a/react-app/src/hook/useAuth.ts
+++ b/react-app/src/hook/useAuth.ts
@@ -1,0 +1,14 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { RootState } from '@/store';
+import { setAuth, clearAuth } from '@/store/slices/authSlice';
+
+export const useAuth = () => {
+  const auth = useSelector((state: RootState) => state.auth);
+  const dispatch = useDispatch();
+
+  return {
+    auth,
+    login: (data: any) => dispatch(setAuth(data)),
+    logout: () => dispatch(clearAuth()),
+  };
+};

--- a/react-app/src/hook/useAuth.ts
+++ b/react-app/src/hook/useAuth.ts
@@ -2,10 +2,12 @@ import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '@/store';
 import { setAuth, clearAuth } from '@/store/slices/authSlice';
 
+// 현재 인증 상태를 반환하는 커스텀 훅
 export const useAuth = () => {
   const auth = useSelector((state: RootState) => state.auth);
   const dispatch = useDispatch();
 
+  // login → setAuth 디스패치, logout → clearAuth 디스패치
   return {
     auth,
     login: (data: any) => dispatch(setAuth(data)),

--- a/react-app/src/pages/Home.tsx
+++ b/react-app/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 const Home = () => {
-  return <div></div>;
+  return <div>홈</div>;
 };
 
 export default Home;

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { setAuth } from '@/store/slices/authSlice';
+import { clearAuth, setAuth } from '@/store/slices/authSlice';
 import { login } from '@/apis/user/login';
+import { useSelector } from 'react-redux';
+import { RootState } from '@/store';
 
 const Login = () => {
+  const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+
   const dispatch = useDispatch();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -11,15 +15,18 @@ const Login = () => {
   const handleLogin = async () => {
     try {
       const response = await login({ username, password });
-      const { user } = response;
+      const { user, accessToken, refreshToken } = response;
 
       dispatch(
         setAuth({
           user,
-          accessToken: null,
-          refreshToken: null,
+          accessToken,
+          refreshToken,
         }),
       );
+
+      setUsername('');
+      setPassword('');
 
       alert('로그인 성공!');
     } catch (error) {
@@ -28,31 +35,47 @@ const Login = () => {
     }
   };
 
-  return (
-    <div className="flex flex-col items-center justify-center h-screen gap-4">
-      <h2 className="text-2xl font-bold">로그인 테스트 페이지</h2>
-      <input
-        type="text"
-        placeholder="아이디"
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
-        className="p-2 border rounded"
-      />
-      <input
-        type="password"
-        placeholder="비밀번호"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        className="p-2 border rounded"
-      />
-      <button
-        onClick={handleLogin}
-        className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600"
-      >
-        로그인
-      </button>
-    </div>
-  );
+  const handleLogout = () => {
+    dispatch(clearAuth());
+    localStorage.removeItem('accessToken');
+  };
+
+  if (!accessToken) {
+    return (
+      <div className="flex flex-col items-center justify-center h-screen gap-4">
+        <h2 className="text-2xl font-bold">로그인 테스트 페이지</h2>
+        <input
+          type="text"
+          placeholder="아이디"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="p-2 border rounded"
+        />
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="p-2 border rounded"
+        />
+        <button
+          onClick={handleLogin}
+          className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600"
+        >
+          로그인
+        </button>
+      </div>
+    );
+  } else {
+    return (
+      <div>
+        <div>로그인 중 입니다.</div>
+        <button className="bg-amber-300" onClick={handleLogout}>
+          로그아웃
+        </button>
+      </div>
+    );
+  }
 };
 
 export default Login;

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -1,9 +1,58 @@
+import { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { setAuth } from '@/store/slices/authSlice';
+import { login } from '@/apis/user/login';
+
 const Login = () => {
-    return (
-        <div>
-            
-        </div>
-    );
+  const dispatch = useDispatch();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      const response = await login({ username, password });
+      const { user } = response;
+
+      dispatch(
+        setAuth({
+          user,
+          accessToken: null,
+          refreshToken: null,
+        }),
+      );
+
+      alert('로그인 성공!');
+    } catch (error) {
+      alert('로그인 실패');
+      console.error(error);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen gap-4">
+      <h2 className="text-2xl font-bold">로그인 테스트 페이지</h2>
+      <input
+        type="text"
+        placeholder="아이디"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        className="p-2 border rounded"
+      />
+      <input
+        type="password"
+        placeholder="비밀번호"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="p-2 border rounded"
+      />
+      <button
+        onClick={handleLogin}
+        className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600"
+      >
+        로그인
+      </button>
+    </div>
+  );
 };
 
 export default Login;

--- a/react-app/src/routes.tsx
+++ b/react-app/src/routes.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter } from 'react-router-dom';
 import Layout from '@/components/Layout/Layout';
-import App from './App';
+import Login from './pages/Login';
+import Home from './pages/Home';
 
 const router = createBrowserRouter([
   {
@@ -9,10 +10,14 @@ const router = createBrowserRouter([
     children: [
       {
         path: '/',
-        element: <App />,
+        element: <Home />,
       },
-      // add more routes...
+      {
+        path: '/login',
+        element: <Login />,
+      },
     ],
   },
 ]);
+
 export default router;

--- a/react-app/src/routes.tsx
+++ b/react-app/src/routes.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import Layout from '@/components/Layout/Layout';
 import Login from './pages/Login';
 import Home from './pages/Home';
+import Vote from './pages/Vote';
 
 const router = createBrowserRouter([
   {
@@ -15,6 +16,10 @@ const router = createBrowserRouter([
       {
         path: '/login',
         element: <Login />,
+      },
+      {
+        path: 'vote',
+        element: <Vote />,
       },
     ],
   },

--- a/react-app/src/store/index.ts
+++ b/react-app/src/store/index.ts
@@ -14,20 +14,24 @@ import authReducer from './slices/authSlice';
 import pageReducer from './slices/pageSlice';
 import timerReducer from './slices/timerSlice';
 
+//  auth 슬라이스만 영구 저장되도록 설정
 const persistConfig = {
   key: 'root',
   storage,
   whitelist: ['auth'],
 };
 
+//  모든 슬라이스 리듀서를 통합
 const rootReducer = combineReducers({
   auth: authReducer,
   page: pageReducer,
   timer: timerReducer,
 });
 
+//  persist 적용된 루트 리듀서를 스토어에 설정
 const persistedReducer = persistReducer(persistConfig, rootReducer);
 
+//  스토어 생성 및 미들웨어 설정
 export const store = configureStore({
   reducer: persistedReducer,
   middleware: (getDefaultMiddleware) =>

--- a/react-app/src/store/index.ts
+++ b/react-app/src/store/index.ts
@@ -1,0 +1,43 @@
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import authReducer from './slices/authSlice';
+import pageReducer from './slices/pageSlice';
+import timerReducer from './slices/timerSlice';
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['auth'],
+};
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+  page: pageReducer,
+  timer: timerReducer,
+});
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+});
+
+export const persistor = persistStore(store);
+export type RootState = ReturnType<typeof rootReducer>;
+export type AppDispatch = typeof store.dispatch;

--- a/react-app/src/store/slices/authSlice.ts
+++ b/react-app/src/store/slices/authSlice.ts
@@ -20,7 +20,7 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    setAuth(state, action: PayloadAction<AuthState>) {
+    setAuth(_state, action: PayloadAction<AuthState>) {
       return action.payload;
     },
     clearAuth() {

--- a/react-app/src/store/slices/authSlice.ts
+++ b/react-app/src/store/slices/authSlice.ts
@@ -1,19 +1,18 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface AuthState {
-  accessToken: string | null;
-  refreshToken: string | null;
   user: {
     userId: number;
-    username: string;
-    randomNickname: string;
+    voted: boolean;
   } | null;
+  accessToken: string | null;
+  refreshToken: string | null;
 }
 
 const initialState: AuthState = {
+  user: null,
   accessToken: null,
   refreshToken: null,
-  user: null,
 };
 
 const authSlice = createSlice({
@@ -21,12 +20,16 @@ const authSlice = createSlice({
   initialState,
   reducers: {
     // 인증 정보를 저장
-    setAuth(_state, action: PayloadAction<AuthState>) {
-      return action.payload;
+    setAuth(state, action: PayloadAction<AuthState>) {
+      state.user = action.payload.user;
+      state.accessToken = action.payload.accessToken;
+      state.refreshToken = action.payload.refreshToken;
     },
     // 초기 상태로 리셋
-    clearAuth() {
-      return initialState;
+    clearAuth(state) {
+      state.user = null;
+      state.accessToken = null;
+      state.refreshToken = null;
     },
   },
 });

--- a/react-app/src/store/slices/authSlice.ts
+++ b/react-app/src/store/slices/authSlice.ts
@@ -20,9 +20,11 @@ const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
+    // 인증 정보를 저장
     setAuth(_state, action: PayloadAction<AuthState>) {
       return action.payload;
     },
+    // 초기 상태로 리셋
     clearAuth() {
       return initialState;
     },

--- a/react-app/src/store/slices/authSlice.ts
+++ b/react-app/src/store/slices/authSlice.ts
@@ -1,0 +1,33 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface AuthState {
+  accessToken: string | null;
+  refreshToken: string | null;
+  user: {
+    userId: number;
+    username: string;
+    randomNickname: string;
+  } | null;
+}
+
+const initialState: AuthState = {
+  accessToken: null,
+  refreshToken: null,
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setAuth(state, action: PayloadAction<AuthState>) {
+      return action.payload;
+    },
+    clearAuth() {
+      return initialState;
+    },
+  },
+});
+
+export const { setAuth, clearAuth } = authSlice.actions;
+export default authSlice.reducer;

--- a/react-app/src/store/slices/pageSlice.ts
+++ b/react-app/src/store/slices/pageSlice.ts
@@ -1,0 +1,22 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface PageState {
+  currentPage: 1 | 2 | 3 | 4;
+}
+
+const initialState: PageState = {
+  currentPage: 1,
+};
+
+const pageSlice = createSlice({
+  name: 'page',
+  initialState,
+  reducers: {
+    setPage(state, action: PayloadAction<1 | 2 | 3 | 4>) {
+      state.currentPage = action.payload;
+    },
+  },
+});
+
+export const { setPage } = pageSlice.actions;
+export default pageSlice.reducer;

--- a/react-app/src/store/slices/timerSlice.ts
+++ b/react-app/src/store/slices/timerSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice } from '@reduxjs/toolkit';
+import dayjs from 'dayjs';
+
+interface TimerState {
+  isAvailable: boolean;
+  lastResetDate: string | null;
+}
+
+const initialState: TimerState = {
+  isAvailable: false,
+  lastResetDate: null,
+};
+
+const timerSlice = createSlice({
+  name: 'timer',
+  initialState,
+  reducers: {
+    updateAvailability(state) {
+      const hour = dayjs().hour();
+      state.isAvailable = hour >= 11 && hour < 14;
+    },
+    resetTimer(state) {
+      state.lastResetDate = dayjs().format('YYYY-MM-DD');
+    },
+  },
+});
+
+export const { updateAvailability, resetTimer } = timerSlice.actions;
+export default timerSlice.reducer;

--- a/react-app/vite.config.ts
+++ b/react-app/vite.config.ts
@@ -6,4 +6,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss(), tsconfigPaths()],
+  server: {
+    port: 3000,
+  },
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #83 

사용자 인증 및 정보를 효율적으로 관리하기 위해 Redux Toolkit을 기반으로 스토어를 구성하고, JWT 기반 인증 처리 (로그인, 로그아웃, 토큰 갱신 등)를 위한 axios 인터셉터 및 API 요청 모듈을 구현합니다.


## 📝작업 내용

- authSlice 추가: accessToken, refreshToken, 사용자 정보 저장
- store.ts: Redux Persist 적용 (auth 상태 유지)
- axiosInstance.ts:
  - 요청 시 accessToken 자동 주입
  - 401 응답 시 refresh token 기반 accessToken 자동 재발급 및 재요청 처리
- useAuth.ts: 로그인/로그아웃 커스텀 훅 구현
- /login 페이지에서 로그인 시 setAuth 디스패치 → 사용자 인증 상태 저장


### 스크린샷 (선택)
![ezgif-892a06e52226fc](https://github.com/user-attachments/assets/0790a87c-0ecc-4ee5-b195-817c8b1897b5)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
