### PR TITLE
FEAT: 인증 상태 로직 관리 수정 및 User API 모듈화 

### DIFF
--- a/react-app/src/apis/user/changePassword.ts
+++ b/react-app/src/apis/user/changePassword.ts
@@ -1,0 +1,11 @@
+import axiosInstance from '../axiosInstance';
+
+export interface ChangePasswordRequest {
+  old_password: string;
+  new_password: string;
+}
+
+export async function changePassword(userId: string, body: ChangePasswordRequest): Promise<void> {
+  const response = await axiosInstance.patch(`/user/${userId}`, body);
+  return response.data;
+}

--- a/react-app/src/apis/user/getUserInfo.ts
+++ b/react-app/src/apis/user/getUserInfo.ts
@@ -1,0 +1,19 @@
+import axiosInstance from '../axiosInstance';
+
+export interface UserInfoRequest {
+  userId: number;
+}
+
+export interface UserInfoResponse {
+  userId: number;
+  username: string;
+  randomNickname: string;
+  selected: boolean;
+  voted: boolean;
+  token?: string | null;
+}
+
+export async function getUserInfo(userId: string): Promise<UserInfoResponse> {
+  const response = await axiosInstance.post(`/user/${userId}`);
+  return response.data;
+}

--- a/react-app/src/apis/user/login.ts
+++ b/react-app/src/apis/user/login.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '../axiosInstance';
+import { UserInfoResponse } from './getUserInfo';
 
 export interface LoginRequest {
   username: string;
@@ -6,21 +7,18 @@ export interface LoginRequest {
 }
 
 export interface LoginResponse {
-  user: {
-    userId: number;
-    voted: boolean;
-  };
+  user: UserInfoResponse | null;
   accessToken: string | null;
   refreshToken: string | null;
 }
 
 export async function login(params: LoginRequest): Promise<LoginResponse> {
   const response = await axiosInstance.post('/user/login', params);
-  const accessToken = response.headers['authorization']?.replace('Bearer ', '');
-  const refreshToken = response.headers['refresh-token'];
+  const accessToken = response.headers['Authorization']?.replace('Bearer ', '') ?? null;
+  const refreshToken = response.headers['refresh-token'] ?? null;
 
   return {
-    user: response.data.user,
+    user: response.data.user as UserInfoResponse,
     accessToken,
     refreshToken,
   };

--- a/react-app/src/apis/user/login.ts
+++ b/react-app/src/apis/user/login.ts
@@ -14,7 +14,7 @@ export interface LoginResponse {
 
 export async function login(params: LoginRequest): Promise<LoginResponse> {
   const response = await axiosInstance.post('/user/login', params);
-  const accessToken = response.headers['Authorization']?.replace('Bearer ', '') ?? null;
+  const accessToken = response.headers['authorization']?.replace('Bearer ', '') ?? null;
   const refreshToken = response.headers['refresh-token'] ?? null;
 
   return {

--- a/react-app/src/pages/ChangePW.tsx
+++ b/react-app/src/pages/ChangePW.tsx
@@ -1,9 +1,55 @@
+import { useState } from 'react';
+import { changePassword } from '@/apis/user/changePassword';
+
 const ChangePW = () => {
-    return (
-        <div>
-            
-        </div>
-    );
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  const handleChangePassword = async () => {
+    try {
+      const userId = localStorage.getItem('userId');
+      if (!userId) throw new Error('로그인 정보 없음');
+
+      await changePassword(userId, {
+        old_password: oldPassword,
+        new_password: newPassword,
+      });
+
+      alert('비밀번호가 변경되었습니다.');
+      setOldPassword('');
+      setNewPassword('');
+    } catch (err) {
+      alert('비밀번호 변경 실패');
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto  ">
+      <h2 className="text-xl font-bold mb-6 text-center">비밀번호 변경 테스트</h2>
+      <div className="mb-4">
+        <label className="font-pm block mb-1">현재 비밀번호</label>
+        <input
+          type="password"
+          value={oldPassword}
+          onChange={(e) => setOldPassword(e.target.value)}
+          className="w-full px-3 py-2 border rounded focus:ring focus:outline-none"
+        />
+      </div>
+      <div className="mb-6">
+        <label className="font-pm block mb-1">새 비밀번호</label>
+        <input
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          className="w-full px-3 py-2 border rounded focus:ring focus:outline-none"
+        />
+      </div>
+      <button onClick={handleChangePassword} className="w-full py-2 text-white rounded ">
+        변경하기
+      </button>
+    </div>
+  );
 };
 
 export default ChangePW;

--- a/react-app/src/pages/Home.tsx
+++ b/react-app/src/pages/Home.tsx
@@ -1,16 +1,3 @@
-import { useToast } from '@/hook/useToast';
-
 export default function Home() {
-  const { showToast } = useToast();
-
-  const handleButtonClick = () => {
-    showToast('버튼이 클릭되었습니다', 'success');
-  };
-
-  return (
-    <div>
-      <h1>Hello</h1>
-      <button onClick={handleButtonClick}>토스트 표시</button>
-    </div>
-  );
+  return <div>홈</div>;
 }

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -18,30 +18,32 @@ const Login = () => {
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-100">
       <div className="bg-white shadow-xl rounded-2xl p-8 w-full max-w-sm">
-        <h2 className="text-2xl font-bold text-center mb-6">로그인 테스트 페이지</h2>
+        <h2 className="font-gumi text-2xl font-bold text-center mb-6">
+          <span className="text-(--color-primary-base)">너</span>로 정했다!
+        </h2>
         <div className="mb-4">
-          <label className="block text-gray-700 mb-2">아이디</label>
+          <label className="font-pm block text-gray-700 mb-2">아이디</label>
           <input
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-primary-base)/70"
             placeholder="아이디를 입력하세요"
           />
         </div>
         <div className="mb-6">
-          <label className="block text-gray-700 mb-2">비밀번호</label>
+          <label className="font-pm block text-gray-700 mb-2">비밀번호</label>
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-(--color-primary-base)/70"
             placeholder="비밀번호를 입력하세요"
           />
         </div>
         <button
           onClick={handleLogin}
-          className="w-full py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition duration-200"
+          className="w-full py-2 bg-(--color-primary-base) text-white font-semibold rounded-lg hover:bg-(--color-primary-hover) transition duration-200"
         >
           로그인
         </button>

--- a/react-app/src/pages/Login.tsx
+++ b/react-app/src/pages/Login.tsx
@@ -1,81 +1,59 @@
 import { useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { clearAuth, setAuth } from '@/store/slices/authSlice';
-import { login } from '@/apis/user/login';
-import { useSelector } from 'react-redux';
-import { RootState } from '@/store';
+import { useAuth } from '@/hook/useAuth';
 
 const Login = () => {
-  const accessToken = useSelector((state: RootState) => state.auth.accessToken);
-
-  const dispatch = useDispatch();
+  const { login, logout } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
 
   const handleLogin = async () => {
     try {
-      const response = await login({ username, password });
-      const { user, accessToken, refreshToken } = response;
-
-      dispatch(
-        setAuth({
-          user,
-          accessToken,
-          refreshToken,
-        }),
-      );
-
-      setUsername('');
-      setPassword('');
-
-      alert('로그인 성공!');
-    } catch (error) {
+      await login(username, password);
+    } catch (e) {
       alert('로그인 실패');
-      console.error(error);
+      console.error(e);
     }
   };
 
-  const handleLogout = () => {
-    dispatch(clearAuth());
-    localStorage.removeItem('accessToken');
-  };
-
-  if (!accessToken) {
-    return (
-      <div className="flex flex-col items-center justify-center h-screen gap-4">
-        <h2 className="text-2xl font-bold">로그인 테스트 페이지</h2>
-        <input
-          type="text"
-          placeholder="아이디"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-          className="p-2 border rounded"
-        />
-        <input
-          type="password"
-          placeholder="비밀번호"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          className="p-2 border rounded"
-        />
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="bg-white shadow-xl rounded-2xl p-8 w-full max-w-sm">
+        <h2 className="text-2xl font-bold text-center mb-6">로그인 테스트 페이지</h2>
+        <div className="mb-4">
+          <label className="block text-gray-700 mb-2">아이디</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+            placeholder="아이디를 입력하세요"
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block text-gray-700 mb-2">비밀번호</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-400"
+            placeholder="비밀번호를 입력하세요"
+          />
+        </div>
         <button
           onClick={handleLogin}
-          className="px-4 py-2 text-white bg-blue-500 rounded hover:bg-blue-600"
+          className="w-full py-2 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-600 transition duration-200"
         >
           로그인
         </button>
-      </div>
-    );
-  } else {
-    return (
-      <div>
-        <div>로그인 중 입니다.</div>
-        <button className="bg-amber-300" onClick={handleLogout}>
+        <button
+          onClick={logout}
+          className="mt-4 w-full py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition duration-200"
+        >
           로그아웃
         </button>
       </div>
-    );
-  }
+    </div>
+  );
 };
 
 export default Login;

--- a/react-app/src/routes.tsx
+++ b/react-app/src/routes.tsx
@@ -3,6 +3,7 @@ import Layout from '@/components/Layout/Layout';
 import Login from './pages/Login';
 import Home from './pages/Home';
 import Vote from './pages/Vote';
+import ChangePW from './pages/ChangePW';
 
 const router = createBrowserRouter([
   {
@@ -20,6 +21,10 @@ const router = createBrowserRouter([
       {
         path: 'vote',
         element: <Vote />,
+      },
+      {
+        path: 'change-password',
+        element: <ChangePW />,
       },
     ],
   },

--- a/react-app/src/store/index.ts
+++ b/react-app/src/store/index.ts
@@ -19,7 +19,7 @@ import toastReducer from './slices/toastSlice';
 const persistConfig = {
   key: 'root',
   storage,
-  whitelist: ['auth'],
+  whitelist: [],
 };
 
 // 모든 슬라이스 리듀서를 통합

--- a/react-app/src/store/slices/authSlice.ts
+++ b/react-app/src/store/slices/authSlice.ts
@@ -1,35 +1,24 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { UserInfoResponse } from '@/apis/user/getUserInfo';
 
 interface AuthState {
-  user: {
-    userId: number;
-    voted: boolean;
-  } | null;
-  accessToken: string | null;
-  refreshToken: string | null;
+  user: UserInfoResponse | null;
 }
 
 const initialState: AuthState = {
   user: null,
-  accessToken: null,
-  refreshToken: null,
 };
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
-    // 인증 정보를 저장
-    setAuth(state, action: PayloadAction<AuthState>) {
+    setAuth(state, action: PayloadAction<{ user: UserInfoResponse }>) {
       state.user = action.payload.user;
-      state.accessToken = action.payload.accessToken;
-      state.refreshToken = action.payload.refreshToken;
     },
     // 초기 상태로 리셋
     clearAuth(state) {
       state.user = null;
-      state.accessToken = null;
-      state.refreshToken = null;
     },
   },
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #110 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- auth 리듀서 구조 변경
  -  이제 로컬스토리지에 `유저 아이디`, `엑세스 토큰`, `리프레시 토큰`이 저장됩니다.
 
### 로그인 
- 로그인 로직을 `useAuth.ts` 파일로 분리하여 인증상태를 관리합니다.
- `LoginResponse`에서 비밀번호를 제외한 유저의 모든 정보(아이디, 이름, 투표 여부 등등)과 더불어, 유저의 토큰 정보를 리턴하도록 수정했습니다.
- 원활한 테스트를 위한 페이지를 구현해뒀습니다:)

### 비밀번호 변경
- API 모듈화만 해뒀습니다. 
- 원활한 테스트를 위한 페이지를 구현해뒀습니다:)

### 유저 정보 조회
API 모듈화만 해뒀습니다. 

### 스크린샷 (선택)
`/login`페이지에서 테스트 완료했습니다.
<img width="569" alt="image" src="https://github.com/user-attachments/assets/96a88025-1970-4ffd-8957-08f6c3a03dfe" />

## 💬리뷰 요구사항(선택)

현재 비밀번호 변경 API 자체가 안 됩니다. 
서버 문제이므로 이를 해결해야 합니다..😅
