### PR TITLE
FIX: 비밀번호 변경 API 유효성 로직 강화

### DIFF
--- a/springboot-app/src/main/java/com/uplus/eureka/user/controller/UserController.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/controller/UserController.java
@@ -144,20 +144,33 @@ public class UserController {
         String oldPassword = passwordUpdateRequest.getOld_password();
         String newPassword = passwordUpdateRequest.getNew_password();
 
-        // 사용자 정보 조회
+        oldPassword = oldPassword.trim();
+        newPassword = newPassword.trim();
+
+        // 입력값 null 또는 공백만 있는 경우 예외 처리
+        if (oldPassword == null || oldPassword.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("현재 비밀번호를 입력해주세요.");
+        }
+
+        if (newPassword == null || newPassword.trim().isEmpty()) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("새 비밀번호를 입력해주세요.");
+        }
+
+        // 사용자 정보 조회 및 현재 비밀번호 검증
         User user = userService.getUser(userId);
         String currentPassword = user.getPassword();
 
-        // 비밀번호 유효성 검사
         if (!oldPassword.equals(currentPassword)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body("현재 비밀번호가 일치하지 않습니다.");
-        } else {
-            if (oldPassword.equals(newPassword)) {
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("새 비밀번호가 현재 비밀번호와 동일합니다.");
-            } else {
-                userService.updatePassword(userId, newPassword);
-                return ResponseEntity.ok("비밀번호 변경 성공");
-            }
         }
+
+        if (oldPassword.equals(newPassword)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("새 비밀번호가 현재 비밀번호와 동일합니다.");
+        }
+
+        // 비밀번호 변경 수행
+        userService.updatePassword(userId, newPassword);
+        return ResponseEntity.ok("비밀번호 변경 성공");
+
     }
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/User.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/user/model/dto/User.java
@@ -18,7 +18,7 @@ public class User implements Serializable {
 	private String username; // Unique
 
 	@Schema(description = "비밀번호", example = "0000")
-	private String password; // 안전을 위해 포함시키지 않도록 주의
+	private String password;
 
 	@Schema(description = "프로필 이미지 경로", example = "/images/profile/1.jpg")
 	private String img;


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #128 

## 📝작업 내용

> 현재 비밀번호, 새 비밀번호 변경 시 공백 비허용, 메시지 추가

### 스크린
![스크린샷 2025-05-12 오후 1 21 58](https://github.com/user-attachments/assets/1c0221d7-10f3-42f6-a600-52ee1014b650)
![스크린샷 2025-05-12 오후 1 22 12](https://github.com/user-attachments/assets/b0f391ca-77a5-4403-8d8b-516c64b75bed)
샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
