### PR TITLE
REFACTOR: #182 랭킹 페이지 useQuery로 리팩토링

### DIFF
--- a/react-app/src/hook/useVoteResults.ts
+++ b/react-app/src/hook/useVoteResults.ts
@@ -1,0 +1,33 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLatestPollIds } from '@/apis/poll/getPollLatest';
+import { getVoteResultByPollId } from '@/apis/vote/getVoteResultByPollId';
+
+export type VoteResult = {
+  pollId: number;
+  questionText: string;
+  username: string;
+  voteCount: number;
+};
+
+export const useVoteResults = () => {
+  return useQuery<VoteResult[], Error>({
+    queryKey: ['voteResults'],
+    queryFn: async () => {
+      const latestPollIds = await getLatestPollIds();
+      const resultData = await Promise.all(
+        latestPollIds.map(async (pollId) => {
+          const result = await getVoteResultByPollId({ pollId });
+          const topResult = result.results[0];
+          return {
+            pollId,
+            questionText: result.questionText,
+            username: topResult?.username ?? '',
+            voteCount: topResult?.voteCount ?? 0,
+          };
+        }),
+      );
+      return resultData;
+    },
+    staleTime: 1000 * 60 * 1, // 1분 동안 fresh
+  });
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Close #182

## 📝 작업 내용

* `useVoteResults` 커스텀 훅 생성하여 vote 결과 비동기 요청을 캡슐화
* `isLoading`, `isError`, `data`, `error` 상태값을 `useQuery`에서 자동으로 관리
* `결과 없음`, `로딩`, `에러`, `결과 렌더링`에 대한 UI 조건 분기 개선


### 스크린샷 (선택)


