### PR TITLE
FEAT: #197 이미지 경로 변경 및 자동으로 isVoted가 모두 초기화 되도록 추가

### DIFF
--- a/react-app/src/pages/ChangePW.tsx
+++ b/react-app/src/pages/ChangePW.tsx
@@ -55,7 +55,7 @@ const ChangePW = () => {
     <div
       className={`flex justify-center items-center w-screen h-screen ${isDesktop ? 'text-[1.2vw]' : 'text-[2.5vw]'}`}
     >
-      <div className="flex justify-center items-center w-[70%] max-w-[900px] h-[80%] rounded-2xl overflow-hidden">
+      <div className="flex justify-center items-center w-[70%] max-w-[900px] h-[80%] rounded-2xl">
         {isDesktop && (
           <img
             src="/assets/images/seal-change-password.png"
@@ -118,9 +118,12 @@ const ChangePW = () => {
             </button>
             <button
               onClick={handlePrev}
-              className="flex justify-center gap-[1vw] w-full mt-2 py-2 font-ps text-gray-400 hover:text-gray-600 transition duration-200"
+              className="flex justify-center items-center gap-[1vw] w-full mt-2 py-2 font-ps text-gray-400 hover:text-gray-600 transition duration-200"
             >
-              <img className="aspect-square" src="/public/assets/images/vector.png" />
+              <img
+                className={`${isDesktop ? 'size-[1.8vw]' : 'size-[3vw]'} aspect-square`}
+                src="/assets/images/vector.png"
+              />
               이전으로
             </button>
           </div>

--- a/springboot-app/src/main/java/com/uplus/eureka/candidate/controller/CandidateController.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/candidate/controller/CandidateController.java
@@ -33,7 +33,7 @@ public class CandidateController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("후보자 생성 중 예상치 못한 오류가 발생했습니다.");
+                    .body(e.getMessage());
         }
     }
     
@@ -44,7 +44,7 @@ public class CandidateController {
     		return ResponseEntity.ok(candidates);
     	} catch (Exception e) {
     		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-    				.body("최근 후보자 검색 중 예상치 못한 오류가 발생했습니다." + e);
+    				.body(e.getMessage());
     	}
     }
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/candidate/model/dao/CandidateDao.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/candidate/model/dao/CandidateDao.java
@@ -15,9 +15,12 @@ public interface CandidateDao {
 	List<PollInfo> getTopPollIds();
 
     // 특정 poll_id에 대해 is_selected가 false인 사용자 4명을 랜덤으로 가져오는 쿼리
-	List<UserInfo> getRandomUsersForPoll(@Param("pollId") int pollId, @Param("limit") int limit);
+	List<UserInfo> getRandomUsersForPoll(@Param("pollId") int pollId);
 
-    // candidates 테이블에 후보자를 추가하는 쿼리
+	// candidate_id가 높은 순으로 16개 가져오는 쿼리
+	List<CandidateInfo> getTopCandidate();
+
+	// candidates 테이블에 후보자를 추가하는 쿼리
     void insertCandidate(@Param("candidate") Candidate candidate);
 
     // user_id에 해당하는 is_selected 값을 true로 업데이트하는 쿼리
@@ -25,9 +28,5 @@ public interface CandidateDao {
     
     // 투표 종료 후 is_selected 값을 false로 업데이트하는 쿼리
     void updateUserSelectedFalse();
-    
-    // candidate_id가 높은 순으로 16개 가져오는 쿼리
-    List<CandidateInfo> getTopCandidate();
-    
     }
 

--- a/springboot-app/src/main/java/com/uplus/eureka/candidate/model/service/CandidateService.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/candidate/model/service/CandidateService.java
@@ -50,7 +50,7 @@ public class CandidateService {
 
             for (Candidate.PollInfo pollInfo : pollInfos) {
                 int pollId = pollInfo.getPollId();
-                List<Candidate.UserInfo> users = candidateDao.getRandomUsersForPoll(pollId, 4);
+                List<Candidate.UserInfo> users = candidateDao.getRandomUsersForPoll(pollId);
 
                 if (users.isEmpty()) {
                     throw new RuntimeException("poll_id " + pollId + "에 대해 선택할 수 있는 사용자가 없습니다.");

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/contoller/VoteController.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/contoller/VoteController.java
@@ -64,6 +64,16 @@ public class VoteController {
             return ResponseEntity.status(e.getStatus()).body(e.getMessage());
         }
     }
+    
+    @PatchMapping("/reset")
+    public ResponseEntity<?> resetVoted() {
+    	try {
+    		voteService.resetIsVoted();
+    		return ResponseEntity.ok().body("성공적으로 초기화 했습니다.");
+    	} catch (VoteException e){
+    		return ResponseEntity.status(e.getStatus()).body(e.getMessage());
+    	}
+    }
 
 }
 

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/model/dao/VoteDao.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/model/dao/VoteDao.java
@@ -20,4 +20,7 @@ public interface VoteDao {
 
     //투표 완료 등록
     int completeVote(@Param("userId") int userId);
+    
+    // isVoted 초기화
+    void resetIsVoted();
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteService.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteService.java
@@ -7,4 +7,5 @@ public interface VoteService {
     VoteResult getVoteResult(int pollId);
     void increaseVoteCount(int pollId, VoteRequest voteRequest);
     boolean completeVote(int userId);
+    void resetIsVoted();
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteServiceImp.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/model/service/VoteServiceImp.java
@@ -60,4 +60,13 @@ public class VoteServiceImp implements VoteService {
         }
         return true;
     }
+    
+    @Override
+    public void resetIsVoted() {
+    	try {
+    		voteDao.resetIsVoted();
+    	} catch (VoteException e) {
+    		throw new VoteException("초기화에 실패했습니다.", HttpStatus.BAD_REQUEST);
+    	}
+    }
 }

--- a/springboot-app/src/main/java/com/uplus/eureka/vote/scheduler/VoteScheduler.java
+++ b/springboot-app/src/main/java/com/uplus/eureka/vote/scheduler/VoteScheduler.java
@@ -1,0 +1,19 @@
+package com.uplus.eureka.vote.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import com.uplus.eureka.vote.contoller.VoteController;
+
+@Component
+public class VoteScheduler {
+	private final VoteController voteController;
+	
+    public VoteScheduler(VoteController voteController) {
+        this.voteController = voteController;
+    }
+
+    @Scheduled(cron = "0 00 00 * * ?", zone = "Asia/Seoul")
+    public void runPatchVoted() {
+    	voteController.resetVoted();
+    }
+}

--- a/springboot-app/src/main/resources/mapper/vote.xml
+++ b/springboot-app/src/main/resources/mapper/vote.xml
@@ -46,5 +46,11 @@
         SET is_voted = true
         WHERE user_id = #{userId}
     </update>
+    
+    <!-- 투표 종료 후 is_voted를 모두 false로 초기화 -->
+    <update id="resetIsVoted" parameterType="java.lang.String">
+    	UPDATE Users
+    	SET is_voted = false
+    </update>
 
 </mapper>


### PR DESCRIPTION
## #️⃣연관된 이슈

> Close #197 

## 📝작업 내용

1. 자동으로 00시 00분에 isVoted를 모두 0으로 초기화하도록 설정함
![Image](https://github.com/user-attachments/assets/ade77c6b-cf58-47de-82b7-b3a835aaf564)
![Image](https://github.com/user-attachments/assets/2c185abe-7c85-4e0e-81cc-eee2b58eafcc)

2. 비밀번호 변경의 '이전으로' 아이콘이 출력되지 않던 상황 수정
![Image](https://github.com/user-attachments/assets/eb167d40-9c44-4eca-a3e9-5d580190e89b)

- [x] isVoted를 0으로 초기화하는 로직 구성
- [x] 자동으로 00시 00분에 isVoted를 모두 0으로 초기화하도록 설정함
- [x] 비밀번호 변경의 '이전으로' 아이콘이 출력되지 않던 상황 수정


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
